### PR TITLE
SUP-201, Challenge details displays swift membership program

### DIFF
--- a/src/js/app/challenge-details/index.html
+++ b/src/js/app/challenge-details/index.html
@@ -370,7 +370,7 @@
                 <h3>Review Style:</h3>
 
                 <div class="inner">
-                  <p><strong>Final Review: </strong><span>Community Review Board</span>
+                  <p><strong>Final Review: </strong><span>{{CD.reviewStyle}}</span>
                     <a onmouseout="hideTooltip('FinalReview');" onmouseover="showTooltip(this, 'FinalReview');" class="tooltip"
                        href="javascript:;"> </a></p>
 
@@ -528,7 +528,7 @@
       </div>
       <div class="tipBody">
       <!--Bugfix refactored-challenge-details-117: Removed unused hyperlink-->
-      Community Review Board performs a thorough review based on scorecards.
+      {{CD.reviewStyleTooltip}}
       </div>
       <div class="corner tl"></div>
       <div class="corner tr"></div>

--- a/src/js/app/challenge-details/js/controllers/challenge-details-controller.js
+++ b/src/js/app/challenge-details/js/controllers/challenge-details-controller.js
@@ -39,6 +39,9 @@
     challengeType = $location.search().type;
 
     var vm = this;
+    // default review style
+    vm.reviewStyle = "";
+    vm.reviewStyleTooltip = "";
 
     vm.callComplete = false;
     vm.scope = $scope;
@@ -357,6 +360,14 @@
     // update peer review button flag
     if (handle && vm.isPeerReviewed && vm.inReview && submitters.indexOf(handle) != -1) {
       vm.challenge.peerReviewDisabled = false;
+    }
+    // challenge review style
+    if (vm.challenge.reviewType == 'PEER') {
+      vm.reviewStyle = 'Peer Review';
+      vm.reviewStyleTooltip = 'Your peers performs a thorough review based on scorecards.';
+    } else {
+      vm.reviewStyle = 'Community Review Board';
+      vm.reviewStyleTooltip = 'Community Review Board performs a thorough review based on scorecards.';
     }
 
     vm.hasCheckpoints = vm.numCheckpointSubmissions > 0;

--- a/src/js/app/challenge-details/js/services/challenge-details-services.js
+++ b/src/js/app/challenge-details/js/services/challenge-details-services.js
@@ -123,7 +123,13 @@
         challenge.submissions = challenge.submissions || [];
 
         if (challenge.event) {
-          challenge.event.url = challenge.event.shortDescription == 'tco15' ? 'http://tco15.topcoder.com/' : tcconfig.communityURL + challenge.event.shortDescription;
+          if (challenge.event.shortDescription == 'tc015') {
+            challenge.event.url = 'http://tco15.topcoder.com/';
+          } else if (challenge.event.shortDescription == 'swiftprogram') {
+            challenge.event.url = 'http://apple.topcoder.com';
+          } else {
+            challenge.event.url = tcconfig.communityURL + '/' + challenge.event.shortDescription;
+          }
         }
 
         var submissionMap = {};


### PR DESCRIPTION
**Original Requirements:**
Currently the event property in the challenge details API is rendered as Eligible Events in the UI.

When the event is the new apple program, we will want to hardcode the link to apple.topcoder.com with the link text set to the description of the event from the JSON. Additionally we'll want to change the heading text from Eligible Events to Eligible Programs in this case ([~tjefts] can you confirm/deny this text change)

**Known Deviations/Missing requirements**
1. "Eligible Events" is still the same i.e. not changed to "Eligible Programs"
2. Tooltip for "Peer Review" review style is "Your peers performs a thorough review based on scorecards."
3. Both INTERNAL and COMMUNITY reviewType are shown as "Community Review Board" in Review Style heading of the page.
