### PR TITLE
SUP-444, Upcoming SRM's section looks hidden beneath the Swift Recognition section in mobile/tablet view

### DIFF
--- a/src/css/my-dashboard.css
+++ b/src/css/my-dashboard.css
@@ -75,7 +75,6 @@
 }
 
 .srm-gadget {
-  max-height: 300px;
 }
 
 .srm-gadget-table td {


### PR DESCRIPTION
Fixed