### PR TITLE
SUP-1050, Hitting back button after any my-dashboard link breaks my-dashboard@

### DIFF
--- a/src/js/app/my-dashboard/js/controllers/my-dashboard-controller.js
+++ b/src/js/app/my-dashboard/js/controllers/my-dashboard-controller.js
@@ -35,6 +35,8 @@
 
     // activate controller
     if (AuthService.isLoggedIn === true) {
+      // SUP-1050, workaround to not cache the page
+      angular.element('#cache-persist').val(null);
       activate();
     } else { // if user is not logged in, return (to avoid extra ajax calls)
       return false;


### PR DESCRIPTION
It was happening because getHandle method is not being called on back button which was happening because of page being marked as cached. For now, workaround it by marking the page non cached because down v2 of dashboard will be a separate app which would not be dependent on tc-site.

@thabofletcher @parthshah fyi