### PR TITLE
SUP-561, list of past challenges for data science is not returning the correct end date

### DIFF
--- a/src/js/app/challenges/jsx/build/challenge-grid-view.js
+++ b/src/js/app/challenges/jsx/build/challenge-grid-view.js
@@ -100,7 +100,6 @@
             genInfo : true
           },
           data_past: {
-            endDate : true,
             genInfo : true
           },
           data_upcoming: {

--- a/src/js/app/challenges/jsx/src/challenge-grid-view.js
+++ b/src/js/app/challenges/jsx/src/challenge-grid-view.js
@@ -100,7 +100,6 @@
             genInfo : true
           },
           data_past: {
-            endDate : true,
             genInfo : true
           },
           data_upcoming: {

--- a/wp/wp-content/themes/tcs-responsive/ng-page-challenges.php
+++ b/wp/wp-content/themes/tcs-responsive/ng-page-challenges.php
@@ -559,13 +559,13 @@ get_header(); ?>
         <div class="val vStartDate">{{dateFormatFilter(row.getProperty('registrationStartDate'), dateFormat)}}</div>
       </div>
 
-      <!--
+      
 
       <div class="row" ng-show="contest.listType == 'upcoming' && row.getProperty('checkpointSubmissionEndDate')">
         <label class="lbl ">Round 1 End</label>
         <div class="val vEndRound">{{dateFormatFilter(row.getProperty('checkpointSubmissionEndDate'), dateFormat)}}</div>
       </div>
-      <div class="row" ng-show="contest.listType != 'active'">
+      <div class="row" ng-show="contest.listType == 'upcoming'"><!-- // not showing past listType until we have correct end date for them -->
         <label class="lbl">End Date</label>
         <div class="val vEndDate">{{dateFormatFilter(row.getProperty('submissionEndDate'), dateFormat)}}</div>
       </div>
@@ -573,7 +573,6 @@ get_header(); ?>
         <label class="lbl">Submit by</label>
         <div class="val vEndDate">{{dateFormatFilter(row.getProperty('submissionEndDate'), dateFormat)}}</div>
       </div>
-      -->
     </div>
   </div>
 </script>


### PR DESCRIPTION
@parthshah @nlitwin Please let me know if anything is wrong here.

-- Removed end date from grid view for past data science challenges
-- Shown end date again in list view for upcoming challenges, earlier solution was removing the end date from both past and upcoming list types.