### PR TITLE
Fix for issue #1093 Add TCO link to the top nav

### DIFF
--- a/src/footer.html
+++ b/src/footer.html
@@ -249,6 +249,7 @@
           ],
           'community': [
               { 'href': '/community/members/', 'text': 'OVERVIEW', 'icon': '/mf/i/nav/members.svg' },
+              { 'href': '/tco', 'text': 'TCO', 'icon': '/mf/i/nav/tco-generic.svg', 'target': '_blank' },
               { 'href': '/community/member-programs/', 'text': 'PROGRAMS', 'icon': '/mf/i/nav/programs.svg' },
               { 'href': 'https://' + tcconfig.forumsAppURL, 'text': 'FORUMS', 'icon': '/mf/i/nav/forums.svg' },
               { 'href': '/community/statistics/', 'text': 'STATISTICS', 'icon': '/mf/i/nav/statistics.svg' },

--- a/wp/wp-content/themes/tcs-responsive/footer.php
+++ b/wp/wp-content/themes/tcs-responsive/footer.php
@@ -268,7 +268,7 @@
           ],
           'community': [
               { 'href': '/community/members/', 'text': 'OVERVIEW', 'icon': '/mf/i/nav/members.svg' },
-              { 'href': '/tco', 'text': 'TCO', 'icon': '/mf/i/nav/tco-generic.svg' },
+              { 'href': '/tco', 'text': 'TCO', 'icon': '/mf/i/nav/tco-generic.svg' },  
               { 'href': '/community/member-programs/', 'text': 'PROGRAMS', 'icon': '/mf/i/nav/programs.svg' },
               { 'href': 'https://' + tcconfig.forumsAppURL, 'text': 'FORUMS', 'icon': '/mf/i/nav/forums.svg' },
               { 'href': '/community/statistics/', 'text': 'STATISTICS', 'icon': '/mf/i/nav/statistics.svg' },


### PR DESCRIPTION
The TCO link for the top nav has been added fore the tc-site.
Just like it is in topcoder-app.
For test visit challenge-details page and hover over menu.